### PR TITLE
Updates bundler to v 2.2.10 due to a vulnerability in the current version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,4 +32,4 @@ DEPENDENCIES
   rspec (~> 3.2)
 
 BUNDLED WITH
-   1.16.2
+   2.2.10


### PR DESCRIPTION
## What
_What change does your pull request propose? ✨_

Dependabot has  flagged bundler as having a vulnerability and has suggested that it be updated. 

dependabot references: [here](https://github.com/octokit/octopoller.rb/security/dependabot/3), [here](https://github.com/octokit/octopoller.rb/security/dependabot/2), and [here](https://github.com/octokit/octopoller.rb/security/dependabot/1)