### PR TITLE
updates all dependencies with patch and minor versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,30 +6,30 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.3)
-    rake (13.0.1)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.0)
+    diff-lcs (1.5.0)
+    rake (13.0.6)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2.2.33)
   octopoller!
   rake (~> 13.0)
   rspec (~> 3.2)
 
 BUNDLED WITH
-   2.2.10
+   2.2.33

--- a/octopoller.gemspec
+++ b/octopoller.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.2.33"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.2"
 end


### PR DESCRIPTION
## What
_What change does your pull request propose? ✨_

This is a follow-up to this [PR](https://github.com/octokit/octopoller.rb/pull/22).  Initially, the dependabot notice cited bundler v2.2.10 as the proper upgrade path to avoid the vulnerability.  Once updated dependabot recommended updating to v2.2.33.

This PR updates all of the other gems patch and minor versions but leaves any versions specified with the pessimistic operator (`~>`) alone (excluding bundler itself, given it was the cause of the original vulnerability and the need to bump the major version).

All tests run ✅  and the gem bundles successfully.