### PR TITLE
Hoists the release infra from octokit.rb, for consistency, to be used to release octopoller

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,6 +15,6 @@ jobs:
         ruby-version: 2.6.x
     - name: Build and test with Rake
       run: |
-        gem install bundler
+        gem install bundler:2.2.33
         bundle install --jobs 4 --retry 3
         bundle exec rake

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@
     1. Update the constant in `lib/octopoller/version.rb` (when bundler is executed the version in the `Gemfile.lock` will be updated)
     1. Commit and push directly to `master`
 1. Run the `script/release` script to cut a release
-1. Draft a new release at https://github.com/octokit/octopoller.rb/releases/new containing the changelog
+1. Draft a new release at <https://github.com/octokit/octopoller.rb/releases/new> containing the changelog from step 1
 
 ## Prerequisites
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+# Releasing a new version of octopoller.rb
+
+1. Create a list of all the changes since the prior release
+    1. Compare the latest release to master using https://github.com/octokit/octopoller.rb/compare/`${latest}`...master
+1. Ensure there are no breaking changes _(if there are breaking changes you'll need to create a release branch without those changes or bump the major version)_
+1. Update the version
+    1. Checkout `master`
+    1. Update the constant in `lib/octopoller/version.rb` (when bundler is executed the version in the `Gemfile.lock` will be updated)
+    1. Commit and push directly to master
+1. Run the `script/release` script to cut a release
+1. Draft a new release at https://github.com/octokit/octopoller.rb/releases/new containing the changelog
+
+## Prerequisites
+
+In order to create a release, you will need to be an owner of the octopoller gem on Rubygems.
+
+Verify with:
+```
+gem owner octopoller
+```
+
+An existing owner can add new owners with:
+```
+gem owner octopoller --add EMAIL
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Releasing a new version of octopoller.rb
 
 1. Create a list of all the changes since the prior release
-    1. Compare the latest release to master using https://github.com/octokit/octopoller.rb/compare/`${latest}`...master
+    1. Compare the previous release to `master` using `https://github.com/octokit/octopoller.rb/compare/`v1.3.3.7...master` (assuming that the last release was `v1.3.3.7`)
 1. Ensure there are no breaking changes _(if there are breaking changes you'll need to create a release branch without those changes or bump the major version)_
 1. Update the version
     1. Checkout `master`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@
 1. Update the version
     1. Checkout `master`
     1. Update the constant in `lib/octopoller/version.rb` (when bundler is executed the version in the `Gemfile.lock` will be updated)
-    1. Commit and push directly to master
+    1. Commit and push directly to `master`
 1. Run the `script/release` script to cut a release
 1. Draft a new release at https://github.com/octokit/octopoller.rb/releases/new containing the changelog
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@
 1. Ensure there are no breaking changes _(if there are breaking changes you'll need to create a release branch without those changes or bump the major version)_
 1. Update the version
     1. Checkout `master`
-    1. Update the constant in `lib/octopoller/version.rb` (when bundler is executed the version in the `Gemfile.lock` will be updated)
+    1. Update the constant in `lib/octopoller/version.rb` (when `bundle` is executed the version in the `Gemfile.lock` will be updated)
     1. Commit and push directly to `master`
 1. Run the `script/release` script to cut a release
 1. Draft a new release at <https://github.com/octokit/octopoller.rb/releases/new> containing the changelog from step 1

--- a/script/package
+++ b/script/package
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Usage: script/gem
+# Updates the gemspec and builds a new gem in the pkg directory.
+
+mkdir -p pkg
+gem build *.gemspec
+mv *.gem pkg

--- a/script/release
+++ b/script/release
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Usage: script/release
+# Build the package, tag a commit, push it to origin, and then release the
+# package publicly.
+
+set -e
+
+version="$(script/package | grep Version: | awk '{print $2}')"
+[ -n "$version" ] || exit 1
+
+echo $version
+git commit --allow-empty -a -m "Release $version"
+git tag "v$version"
+git push origin
+git push origin "v$version"
+gem push pkg/*-${version}.gem


### PR DESCRIPTION
## What
_What change does your pull request propose? ✨_

This adds a bit of release infrastructure (sourced from [octokit.rb](https://github.com/octokit/octokit.rb)) to help get us closer to a more consistent release format.  

Updates include:

1. Updates ruby.yml so that the version of bundler that is installed matches what is used in the dev spec and gem files
2. Adds a `RELEASE` doc so that other owners can more easily release this gem
3. Adds package and release scripts in support of a more "automatic" approach to releasing octopoller 