### PR TITLE
Switch to ruby/setup-ruby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.x
     - name: Build and test with Rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Ruby 2.6
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - name: Build and test with Rake
       run: |
         gem install bundler:2.2.33


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
This will resolve a failing build seen [here](https://github.com/octokit/octopoller.rb/actions/runs/3678406359/jobs/6221626504). 

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Builds use actions/setup-ruby (which is deprecated) instead of ruby/setup-ruby, resulting in the following error:

```
NOTE: This action is deprecated and is no longer maintained.
Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
------------------------
Error: Version 2.6.x not found
```

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Build uses ruby/setup-ruby.


### Other information
<!-- Any other information that is important to this PR  -->

* This came up while I was looking at #30. 

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [X] No

If `Yes`, what's the impact:  

* N/A


