### PR TITLE
[feat]: Allow wait to accept 0, false and nil to disable waiting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Octopoller exposes a single function `poll`. Here is what the API looks like:
 #
 # wait      - The time delay in seconds between polls (default is 1 second)
 #           - When given the argument `:exponentially` the action will be retried with exponetial backoff
+#           - When given 0, false or nil, the action will be retried without wait
 # timeout   - The maximum number of seconds the poller will execute
 # retries   - The maximum number of times the action will be retried
 # yield     - A block that will execute, and if `:re_poll` is returned it will re-run

--- a/lib/octopoller.rb
+++ b/lib/octopoller.rb
@@ -16,6 +16,8 @@ module Octopoller
   # raise     - Raises an Octopoller::TimeoutError if the timeout is reached
   # raise     - Raises an Octopoller::TooManyAttemptsError if the retries is reached
   def poll(wait: 1, timeout: nil, retries: nil)
+    wait = 0 if [nil, false].include?(wait)
+
     Octopoller.validate_arguments(wait, timeout, retries)
     exponential_backoff = (wait == :exponentially)
 
@@ -45,7 +47,7 @@ module Octopoller
       raise ArgumentError, "Must pass an argument to either `timeout` or `retries`"
     end
     exponential_backoff = wait == :exponentially
-    raise ArgumentError, "Cannot wait backwards in time" unless exponential_backoff || wait.positive?
+    raise ArgumentError, "Cannot wait backwards in time" if !exponential_backoff && wait.negative?
     raise ArgumentError, "Timed out without even being able to try" if timeout&.negative?
     raise ArgumentError, "Cannot retry something a negative number of times" if retries&.negative?
   end


### PR DESCRIPTION
Resolves #39

----

### Before the change?

Only `:exponentially` or a positive number was accepted as the `wait` parameter.

### After the change?

`0`, `false` and `nil` are accepted as the `wait` parameter to disable waiting.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

